### PR TITLE
Lock thread after removal

### DIFF
--- a/reddit.py
+++ b/reddit.py
@@ -24,6 +24,7 @@ class Reddit:
         try:
             submission = self.reddit.submission(id=post_id)
             submission.mod.remove()
+            submission.mod.lock()
         except Exception as e:
             raise ValueError(str(e))
         if reasons is not None:

--- a/reddit.py
+++ b/reddit.py
@@ -24,11 +24,11 @@ class Reddit:
         try:
             submission = self.reddit.submission(id=post_id)
             submission.mod.remove()
-            submission.mod.lock()
         except Exception as e:
             raise ValueError(str(e))
         if reasons is not None:
             submission.reply(reasons).mod.distinguish()
+            submission.mod.lock()
         if is_report:
             response = await posts.mark_report_resolved(post_id)
         else:


### PR DESCRIPTION
According to the latest [Town Hall](https://www.reddit.com/r/kpop/comments/a23l6m/town_hall_december_2018/?utm_content=title&utm_medium=hot&utm_source=reddit&utm_name=kpop), the thread should be locked after removal. This PR reflects the decision made.